### PR TITLE
Update tag search string to search for any whitespace, not just the space character

### DIFF
--- a/zk
+++ b/zk
@@ -461,7 +461,7 @@ function remove() {
 
 function find_tag() {
   tag="${1}"
-  tag="#${tag} "
+  tag="#${tag}\s"
   search_content "${tag}"
 }
 


### PR DESCRIPTION
The tag command that searches for tags in a zk directory currently expects tags to be identified by a hashtag (#) and followed by a space. This does not find tags delimited by other whitespace (ex. carriage returns and tabs). To resolve, use the regex whitespace identifier as the tag end delimiter "\s" instead of the space character.