### PR TITLE
add 'push' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Commands:
   oe, open-emacs    Open an existing zettel in emacs
   oc, open-code     Open an existing zettel in Visual Studio Code
   ob, open-browser  Open an existing zettel in github using OS default browser
+  p, push           Push zettels to GitHub
   c, cat            Print an existing zettel to terminal
   t, tag            Search zettels for a specific tag
   s, search         Search for a sub string within all zettels

--- a/zk
+++ b/zk
@@ -24,7 +24,7 @@ Commands:
   oe, open-emacs    Open an existing zettel in emacs
   oc, open-code     Open an existing zettel in Visual Studio Code
   ob, open-browser  Open an existing zettel in github using OS default browser
-  p, push           Push notes to GitHub
+  p, push           Push zettels to GitHub
   c, cat            Print an existing zettel to terminal
   t, tag            Search zettels for a specific tag
   s, search         Search for a sub string within all zettels
@@ -314,7 +314,7 @@ function open_browser() {
 function push() {
     cwd=$(pwd)
     cd "$ZETTELKASTEN_DIR"
-    msg="Regenerated at $(date -u '+%Y-%m-%d %H:%M:%S') UTC"
+    msg="Regenerated at $(get_datestamp)"
     git add .
     git commit -m "$msg"
     git push --quiet

--- a/zk
+++ b/zk
@@ -24,6 +24,7 @@ Commands:
   oe, open-emacs    Open an existing zettel in emacs
   oc, open-code     Open an existing zettel in Visual Studio Code
   ob, open-browser  Open an existing zettel in github using OS default browser
+  p, push           Push notes to GitHub
   c, cat            Print an existing zettel to terminal
   t, tag            Search zettels for a specific tag
   s, search         Search for a sub string within all zettels
@@ -310,6 +311,16 @@ function open_browser() {
   $ZETTELKASTEN_BROWSER_COMMAND "https://github.com/$github_endpoint/tree/master/$ZETTELKASTEN_GIT_DIR/$zettel"
 }
 
+function push() {
+    cwd=$(pwd)
+    cd "$ZETTELKASTEN_DIR"
+    msg="Regenerated at $(date -u '+%Y-%m-%d %H:%M:%S') UTC"
+    git add .
+    git commit -m "$msg"
+    git push --quiet
+    cd "$cwd";
+}
+
 function link() {
   from_link=$1
   to_link=$2
@@ -547,7 +558,11 @@ function main() {
     "open-browser" | "ob")
       open_browser "$2"
       ;;
-    
+
+    "push" | "p")
+      push
+      ;;
+
     "cat" | "c")
       open_editor "cat" "$2"
       ;;


### PR DESCRIPTION
If someone doesn't want to use auto git push, they can push notes to GitHub themselves easily with this new push command. 

I found myself, without wanting to use auto git push, pushing notes manually, therefore I believe adding a separate push command one people can use whenever is useful.